### PR TITLE
get the hashing libraries used by the benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ gobench2csv:
 	go build -o build/gobench2csv cmd/gobench2csv/main.go
 
 hashing: results
+	@go get -t ./...
 	@rm -rf ./results/hashing.*
 	@go test ./hashing -benchmem -bench=. | tee ./results/hashing.log
 	@Rscript plotting/gobench_multi_nsop.r ./results/hashing.log ./results/hashing.png


### PR DESCRIPTION
On a machine that doesn't have the libraries installed, `make hashing` doesn't do the right thing.