### PR TITLE
Add highly optimized HTTP parsing for key/value extraction

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -62,7 +62,7 @@ imports:
 - name: github.com/surge/cityhash
   version: cdd6a94144ab18dd21ad865a3aa6837585bffa15
 - name: github.com/tidwall/evio
-  version: 751f59108ad87aaef43e243de036301d233baddb
+  version: cc7a209dcbe6fa42dcc5116377c983fc25f2252a
   subpackages:
   - internal
 - name: github.com/tidwall/fastlane

--- a/http/evio.go
+++ b/http/evio.go
@@ -1,51 +1,50 @@
-package http
+package main
 
-// package main
+import (
+	"log"
+	"runtime"
 
-// import (
-// 	"fmt"
-// 	"log"
-// 	"runtime"
+	"github.com/tidwall/evio"
+)
 
-// 	"github.com/tidwall/evio"
-// )
+func main() {
+	// const responseString = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"
+	// const responseString = "HTTP/1.1 204\r\n\r\n"
+	const responseString = "HTTP/1.1 204\r\n\r\n"
+	responseBuffer := []byte(responseString)
 
-// func main() {
-// 	const responseString = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"
-// 	responseBuffer := []byte(responseString)
+	buffer := make([]byte, 0, len(responseBuffer)*10000)
+	for i := 0; i < 10000; i++ {
+		buffer = append(buffer, responseBuffer...)
+	}
 
-// 	buffer := make([]byte, 0, len(responseBuffer)*10000)
-// 	for i := 0; i < 10000; i++ {
-// 		buffer = append(buffer, responseBuffer...)
-// 	}
+	var events evio.Events
+	events.Serving = func(s evio.Server) (action evio.Action) {
+		log.Printf("serving %s\n", s.Addrs[0])
+		return
+	}
+	events.Opened = func(id int, info evio.Info) (out []byte, opts evio.Options, ctx interface{}, action evio.Action) {
+		// Reuse the input buffer on Data callbacks to avoid unneeded alloc.
+		opts.ReuseInputBuffer = true
+		return
+	}
+	events.Data = func(id int, ctx interface{}, in []byte) (out []byte, action evio.Action) {
+		// Calculate how many requests we have. Each request is 40 bytes.
+		// Yes this is a hack but this benchmark is measuring pure IO performance
+		// of evio so don't judge me.
+		// for i := 0; i < len(in); i++ {
+		// 	if in[i] == 'k' {
 
-// 	var events evio.Events
-// 	events.Serving = func(s evio.Server) (action evio.Action) {
-// 		log.Printf("serving %s\n", s.Addrs[0])
-// 		return
-// 	}
-// 	events.Opened = func(id int, info evio.Info) (out []byte, opts evio.Options, ctx interface{}, action evio.Action) {
-// 		// Reuse the input buffer on Data callbacks to avoid unneeded alloc.
-// 		opts.ReuseInputBuffer = true
-// 		return
-// 	}
-// 	events.Data = func(id int, ctx interface{}, in []byte) (out []byte, action evio.Action) {
-// 		// Calculate how many requests we have. Each request is 40 bytes.
-// 		// Yes this is a hack but this benchmark is measuring pure IO performance
-// 		// of evio so don't judge me.
-// 		// for i := 0; i < len(in); i++ {
-// 		// 	if in[i] == 'k' {
+		// 	}
+		// }
+		// keyLocation := bytes.IndexByte(in, 'k')
+		// fmt.Println(keyLocation)
 
-// 		// 	}
-// 		// }
-// 		// keyLocation := bytes.IndexByte(in, 'k')
-// 		// fmt.Println(keyLocation)
-
-// 		numberOfRequests := len(in) / 40
-// 		fmt.Printf("%q\n", in)
-// 		out = buffer[:numberOfRequests*len(responseBuffer)]
-// 		return
-// 	}
-// 	events.NumLoops = runtime.NumCPU() / 2
-// 	evio.Serve(events, "tcp://0.0.0.0:8000?reuseport=true")
-// }
+		numberOfRequests := len(in) / 40
+		// fmt.Printf("%q\n", in)
+		out = buffer[:numberOfRequests*len(responseBuffer)]
+		return
+	}
+	events.NumLoops = runtime.NumCPU() / 2
+	evio.Serve(events, "tcp://0.0.0.0:8000?reuseport=true")
+}

--- a/http/evio.go
+++ b/http/evio.go
@@ -1,39 +1,51 @@
-package main
+package http
 
-import (
-	"log"
-	"runtime"
+// package main
 
-	"github.com/tidwall/evio"
-)
+// import (
+// 	"fmt"
+// 	"log"
+// 	"runtime"
 
-func main() {
-	const responseString = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 12\r\n\r\nHello World\r\n"
-	responseBuffer := []byte(responseString)
+// 	"github.com/tidwall/evio"
+// )
 
-	buffer := make([]byte, 0, len(responseBuffer)*10000)
-	for i := 0; i < 10000; i++ {
-		buffer = append(buffer, responseBuffer...)
-	}
+// func main() {
+// 	const responseString = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"
+// 	responseBuffer := []byte(responseString)
 
-	var events evio.Events
-	events.Serving = func(s evio.Server) (action evio.Action) {
-		log.Printf("serving %s\n", s.Addrs[0])
-		return
-	}
-	events.Opened = func(id int, info evio.Info) (out []byte, opts evio.Options, ctx interface{}, action evio.Action) {
-		// Reuse the input buffer on Data callbacks to avoid unneeded alloc.
-		opts.ReuseInputBuffer = true
-		return
-	}
-	events.Data = func(id int, ctx interface{}, in []byte) (out []byte, action evio.Action) {
-		// Calculate how many requests we have. Each request is 40 bytes.
-		// Yes this is a hack but this benchmark is measuring pure IO performance
-		// of evio so don't judge me.
-		numberOfRequests := len(in) / 40
-		out = buffer[:numberOfRequests*len(responseBuffer)]
-		return
-	}
-	events.NumLoops = runtime.NumCPU() / 2
-	evio.Serve(events, "tcp://0.0.0.0:8000?reuseport=true")
-}
+// 	buffer := make([]byte, 0, len(responseBuffer)*10000)
+// 	for i := 0; i < 10000; i++ {
+// 		buffer = append(buffer, responseBuffer...)
+// 	}
+
+// 	var events evio.Events
+// 	events.Serving = func(s evio.Server) (action evio.Action) {
+// 		log.Printf("serving %s\n", s.Addrs[0])
+// 		return
+// 	}
+// 	events.Opened = func(id int, info evio.Info) (out []byte, opts evio.Options, ctx interface{}, action evio.Action) {
+// 		// Reuse the input buffer on Data callbacks to avoid unneeded alloc.
+// 		opts.ReuseInputBuffer = true
+// 		return
+// 	}
+// 	events.Data = func(id int, ctx interface{}, in []byte) (out []byte, action evio.Action) {
+// 		// Calculate how many requests we have. Each request is 40 bytes.
+// 		// Yes this is a hack but this benchmark is measuring pure IO performance
+// 		// of evio so don't judge me.
+// 		// for i := 0; i < len(in); i++ {
+// 		// 	if in[i] == 'k' {
+
+// 		// 	}
+// 		// }
+// 		// keyLocation := bytes.IndexByte(in, 'k')
+// 		// fmt.Println(keyLocation)
+
+// 		numberOfRequests := len(in) / 40
+// 		fmt.Printf("%q\n", in)
+// 		out = buffer[:numberOfRequests*len(responseBuffer)]
+// 		return
+// 	}
+// 	events.NumLoops = runtime.NumCPU() / 2
+// 	evio.Serve(events, "tcp://0.0.0.0:8000?reuseport=true")
+// }

--- a/http/parse_test.go
+++ b/http/parse_test.go
@@ -1,4 +1,4 @@
-package http
+package main
 
 import (
 	"bytes"

--- a/http/parse_test.go
+++ b/http/parse_test.go
@@ -1,0 +1,30 @@
+package http
+
+import (
+	"bytes"
+	"testing"
+)
+
+const requests = "PUT / HTTP/1.1\r\nk: 0000000002\r\nv: 0000000002\r\nHost: 127.0.0.1:8000\r\n\r\n"
+
+func BenchmarkScanParser(b *testing.B) {
+	buffer := []byte(requests)
+	b.ResetTimer()
+
+	for i := 0; i < len(buffer); i++ {
+		if buffer[i] == 'k' {
+
+		}
+		if buffer[i] == 'v' {
+
+		}
+	}
+
+}
+
+func BenchmarkIndexByteParser(b *testing.B) {
+	buffer := []byte(requests)
+	b.ResetTimer()
+	idx := bytes.IndexByte(buffer, 'k')
+	idx = bytes.IndexByte(buffer[idx:], 'v')
+}

--- a/http/parse_test.go
+++ b/http/parse_test.go
@@ -1,30 +1,89 @@
 package main
 
 import (
-	"bytes"
+	"crypto/rand"
+	"encoding/binary"
 	"testing"
 )
 
-const requests = "PUT / HTTP/1.1\r\nk: 0000000002\r\nv: 0000000002\r\nHost: 127.0.0.1:8000\r\n\r\n"
+const requests = "PUT / HTTP/1.0\r\n"
 
-func BenchmarkScanParser(b *testing.B) {
-	buffer := []byte(requests)
-	b.ResetTimer()
+// createHTTPReqyestBuffer creates a HTTP request buffer payload with the following layout.
+//
+// PUT / HTTP/1.0\r\n[uint32][uint32][key-bytes][value-bytes]
+func createHTTPRequestBuffer(key []byte, value []byte) []byte {
+	lengthOfRequestHeader := len(requests)
+	lengthOfKey := len(key)
+	lengthOfValue := len(value)
+	buffer := make([]byte, lengthOfRequestHeader+4+4+lengthOfKey+lengthOfValue)
 
-	for i := 0; i < len(buffer); i++ {
-		if buffer[i] == 'k' {
+	offset := 0
+	copy(buffer[offset:lengthOfRequestHeader], requests)
+	offset += lengthOfRequestHeader
+	binary.LittleEndian.PutUint32(buffer[offset:offset+4], uint32(lengthOfKey))
+	offset += 4
+	binary.LittleEndian.PutUint32(buffer[offset:offset+4], uint32(lengthOfValue))
+	offset += 4
+	copy(buffer[offset:], key)
+	offset += len(key)
+	copy(buffer[offset:], value)
 
-		}
-		if buffer[i] == 'v' {
-
-		}
-	}
-
+	return buffer
 }
 
-func BenchmarkIndexByteParser(b *testing.B) {
-	buffer := []byte(requests)
+func createRandomKeyValue(keyLength int, valueLength int) ([]byte, []byte) {
+	key := make([]byte, keyLength)
+	value := make([]byte, valueLength)
+	rand.Read(key)
+	rand.Read(value)
+	return key, value
+}
+
+func createRequests(numberOfRequests int, keyLength int, valueLength int) []byte {
+	lengthOfRequestHeaders := len(requests) * numberOfRequests
+	lengthOfOffsets := (4 + 4) * numberOfRequests
+	lengthOfKeys := keyLength * numberOfRequests
+	lengthOfValues := valueLength * numberOfRequests
+	lengthOfBuffer := lengthOfRequestHeaders + lengthOfOffsets + lengthOfKeys + lengthOfValues
+	buffer := make([]byte, lengthOfBuffer)
+
+	offset := 0
+	for i := 0; i < numberOfRequests; i++ {
+		key, value := createRandomKeyValue(16, 64)
+		request := createHTTPRequestBuffer(key, value)
+		copy(buffer[offset:lengthOfBuffer], request)
+		offset += len(request)
+	}
+	return buffer
+}
+
+// BenchmarkFixedParser1000 splits b.N desired iterations from gobench (example: 200000000)
+// into 1000 batches of runs so that we can parse large chunks of requests and invalidate
+// CPU caches correctly without running out of memory trying to allocate 200000000 requests.
+func BenchmarkFixedParser1000(b *testing.B) {
+	benchmarkFixedParser(b, b.N, 1000, 16, 64)
+}
+
+func benchmarkFixedParser(b *testing.B, numberOfRequests int, splitSize int, keyLength int, valueLength int) {
+	buffer := createRequests(numberOfRequests/splitSize, keyLength, valueLength)
 	b.ResetTimer()
-	idx := bytes.IndexByte(buffer, 'k')
-	idx = bytes.IndexByte(buffer[idx:], 'v')
+
+	for c := 0; c < splitSize; c++ {
+		offset := 0
+		for i := 0; i < numberOfRequests/splitSize; i++ {
+			offset += 16
+			lengthOfKey := int(binary.LittleEndian.Uint32(buffer[offset : offset+4]))
+			offset += +4
+			lengthOfValue := int(binary.LittleEndian.Uint32(buffer[offset : offset+4]))
+			offset += 4
+			key := buffer[offset : offset+lengthOfKey]
+			offset += lengthOfKey
+			value := buffer[offset : offset+lengthOfValue]
+			offset += lengthOfValue
+
+			_ = key
+			_ = value
+			b.SetBytes(1)
+		}
+	}
 }


### PR DESCRIPTION
This adds some preliminary experimentations around parsing HTTP requests that contain a key/value payload. This takes extreme liberties and sometimes violates HTTP 1.1 by using HTTP pipelining but with HTTP 1.0 header format to reduce payload size.

I have minimized the request to the following format for efficiency.
```
PUT / HTTP/1.0\r\n[uint32][uint32][key-bytes][value-bytes]
```

This is acceptable because we control both the HTTP client and HTTP server. The goal is to find the fastest way possible to transfer and parse key/value pairs over HTTP.

`BenchmarkFixedParser1000` benchmarks the parsing performance. To give realistic results we couldn't parse the same request buffer over and over because that will benefit too highly from CPU cache locality.

Instead `go bench` gives us a `b.N` of say `200,000,000` and we split it into `1,000` runs which makes up for `200,000` HTTP requests parsed each run. We do this so that we can exercise production like memory access without skewing benchmark results by unfairly parsing the same bytes over and over.

# Benchmark results
This benchmark shows single threaded performance of `109 million` key/value pairs parsed.
```
BenchmarkFixedParser-8   200000000         9.11 ns/op	 0 B/op	       0 allocs/op
```