### PR TITLE
calls: added go plugin benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,10 @@ results:
 	@echo "Create results folder..."
 	@mkdir results
 
-calls: results
+calls/func.plugin.so: calls/plugin/nop.go
+	@go build -buildmode=plugin -o $@ $<
+
+calls: results calls/func.plugin.so
 	@rm -rf ./results/calls.*
 	@go test ./calls -benchmem -bench=. | tee ./results/calls.log
 

--- a/calls/call_test.go
+++ b/calls/call_test.go
@@ -1,10 +1,27 @@
 package calls
 
 import (
+	"plugin"
 	"testing"
 
 	"github.com/kellabyte/go-benchmarks/calls/asm"
 )
+
+var pluginNop func()
+
+func init() {
+	plug, err := plugin.Open("func.plugin.so")
+	if err != nil {
+		panic(err)
+	}
+
+	symNop, err := plug.Lookup("Nop")
+	if err != nil {
+		panic(err)
+	}
+
+	pluginNop = symNop.(func())
+}
 
 func BenchmarkCGO(b *testing.B) {
 	for i := 0; i < b.N; i++ {
@@ -16,6 +33,13 @@ func BenchmarkCGO(b *testing.B) {
 func BenchmarkGo(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		Nop()
+		b.SetBytes(1)
+	}
+}
+
+func BenchmarkPlugin(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		pluginNop()
 		b.SetBytes(1)
 	}
 }

--- a/calls/plugin/nop.go
+++ b/calls/plugin/nop.go
@@ -1,0 +1,7 @@
+package main
+
+func Nop() {}
+
+func main() {
+
+}


### PR DESCRIPTION
```
goos: darwin
goarch: amd64
pkg: github.com/kellabyte/go-benchmarks/calls
BenchmarkCGO-8          20000000                64.6 ns/op        15.48 MB/s           0 B/op          0 allocs/op
BenchmarkGo-8           2000000000               1.67 ns/op      598.58 MB/s           0 B/op          0 allocs/op
BenchmarkPlugin-8       2000000000               1.71 ns/op      585.45 MB/s           0 B/op          0 allocs/op
BenchmarkAsm-8          2000000000               1.75 ns/op      570.68 MB/s           0 B/op          0 allocs/op
PASS
ok      github.com/kellabyte/go-benchmarks/calls        12.155s
```